### PR TITLE
Inline specification references

### DIFF
--- a/.semignore
+++ b/.semignore
@@ -1,0 +1,5 @@
+# These files need to be ignored because they contain valid semcheck inline references
+./internal/inline/parser.go
+./internal/inline/parser_test.go
+./internal/processor/rule_builder_test.go
+./specs/inline.md

--- a/.semignore
+++ b/.semignore
@@ -3,3 +3,7 @@
 ./internal/inline/parser_test.go
 ./internal/processor/rule_builder_test.go
 ./specs/inline.md
+./TODO.md
+./site/src/components/quickstart.astro
+./README.md
+./CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+Changelog entries should be added to this file in reverse chronological order. On release change the version number in the header and create a new [Unreleased] section. Use subsections "Added", "Changed" and "Removed" to distinguish between different types of changes, omit a subsection if there are no changes.
+
+## [Unreleased]
+
+### Added
+- **Inline Specification References**: Link specifications directly in code comments using `semcheck:file()`, `semcheck:rfc()`, or `semcheck:url()` commands
+- **New landing page**: Added a dedicated landing page hosted on [semcheck.ai](https://semcheck.ai)
+- **Expanded Eval test cases**: Added additional test cases for the evaluation suite that test larger codebases and specifications
+
+### Changed
+  - **Config**: Rules are now optional, semcheck can run with only inline specification references
+
+### Removed
+- The `confidence_threshold` configuration option has been marked as deprecated, and will be removed in a future release. We found that LLMs almost always report high confidence levels and that this mechanism doesn't bring much value.
+
+
+## v1.0
+
+Initial release of semcheck.

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,8 @@
 # TODOs
 
+Issues
+- `semcheck spec/inline.md` currently doesn't check for inline spec references that mention this file, only rules.
+
 Experiments
 - Consider the developer workflow, requirements -> design -> implementation plan -> execute -> verify
   - implementation plan and execution are left to the dev/coding agent
@@ -25,6 +28,7 @@ Maturity
 
 Cool
 - Auto derive rules from existing specification files and implementation
+- You can provide semantic descriptions of subsections for specs: e.g. semcheck:file(spec.md, Section 14.3)
 - Implementation or specification 'quotes' to be displayed along issues
   - or more generally, improve UX when trying to backtrack an issue to it's origin
 - Have a "thinking" preview in the terminal saying things like "considering function arguments in config validation..."

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -80,7 +80,7 @@ func Execute() error {
 		}
 	} else if *preCommit {
 		fmt.Println("Running semcheck on staged files...")
-		stagedFiles := matcher.GetStagedFiles()
+		stagedFiles := processor.GetStagedFiles(workingDir)
 		matchedResults, err = matcher.MatchFiles(stagedFiles)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error matching staged files: %v\n", err)

--- a/cmd/cli/init.go
+++ b/cmd/cli/init.go
@@ -28,9 +28,11 @@ base_url: "http://localhost:11434"
 {{- end }}
 
 # Rules define which files to check and their specifications
+# You can also link specification files directly from source code using comments:
+# 	// semcheck:file(./path/to/spec.md)
 rules:
   - name: "example-rule"
-    description: "Example rule - edit this to match your project"
+    description: "Example rule - edit or remove this to match your project"
     enabled: true
     files:
       include:

--- a/internal/checker/semantic.go
+++ b/internal/checker/semantic.go
@@ -35,6 +35,17 @@ type SemanticChecker struct {
 	workingDir string
 }
 
+var inlineRule = config.Rule{
+	Name:        "inline-ref",
+	Description: "Check for discrepancies near semcheck's inline references",
+	Enabled:     true,
+	Files:       config.FilePattern{}, // Not used after matching phase, empty here
+	Specs:       []config.Spec{},
+	Prompt: `Inline specification references look as follows and are usually used within a comment:
+				  semcheck:[type](args), for example: semcheck:file(api-compliance.md)`,
+	FailOn: "error", // TODO: not configurable
+}
+
 func NewSemanticChecker(cfg *config.Config, client providers.Client[providers.IssueResponse], workingDir string) *SemanticChecker {
 	return &SemanticChecker{
 		config:     cfg,
@@ -167,6 +178,9 @@ func (c *SemanticChecker) mergeUnique(slice1, slice2 []string) []string {
 }
 
 func (c *SemanticChecker) findRule(name string) *config.Rule {
+	if name == inlineRule.Name {
+		return &inlineRule
+	}
 	for i := range c.config.Rules {
 		if c.config.Rules[i].Name == name {
 			return &c.config.Rules[i]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,10 +94,6 @@ func (c *Config) validate() error {
 		return fmt.Errorf("api_key is required for provider %s", c.Provider)
 	}
 
-	if len(c.Rules) == 0 {
-		return fmt.Errorf("at least one rule is required")
-	}
-
 	ruleNames := make(map[string]bool)
 	for i, rule := range c.Rules {
 		if rule.Name == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -179,16 +179,6 @@ func TestConfig_validate(t *testing.T) {
 			wantError: true,
 		},
 		{
-			name: "unsupported provider",
-			config: Config{
-				Version:  "1.0",
-				Provider: "unsupported",
-				Model:    "gpt-4",
-				APIKey:   "test-key",
-			},
-			wantError: true,
-		},
-		{
 			name: "missing model",
 			config: Config{
 				Version:  "1.0",
@@ -206,7 +196,7 @@ func TestConfig_validate(t *testing.T) {
 				APIKey:   "test-key",
 				Rules:    []Rule{},
 			},
-			wantError: true,
+			wantError: false,
 		},
 	}
 

--- a/internal/inline/parser.go
+++ b/internal/inline/parser.go
@@ -18,7 +18,7 @@ const (
 	Invalid InlineCommand = "invalid"
 )
 
-const semcheckPrefix = "semcheck"
+const semcheckPrefix = "semcheck:"
 
 var (
 	ErrorInvalidCommand                       = errors.New("invalid command")
@@ -91,12 +91,9 @@ func consumeCommandArgs(argString string) ([]string, error) {
 }
 
 func consumeCommandName(commandArgs string) (InlineCommand, string) {
-	if len(commandArgs) == 0 || commandArgs[0] != ':' {
-		// A colon is required to delineate the command from the prefix (i.e. semcheck:command)
+	if len(commandArgs) == 0 {
 		return Invalid, ""
 	}
-
-	commandArgs = commandArgs[1:]
 
 	if strings.HasPrefix(commandArgs, "file") {
 		return File, commandArgs[4:]

--- a/internal/inline/parser.go
+++ b/internal/inline/parser.go
@@ -1,0 +1,146 @@
+package inline
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type InlineCommand string
+
+const (
+	File    InlineCommand = "file"
+	RFC     InlineCommand = "rfc"
+	URL     InlineCommand = "url"
+	Invalid InlineCommand = "invalid"
+)
+
+const semcheckPrefix = "semcheck"
+
+var (
+	ErrorInvalidCommand                       = errors.New("invalid command")
+	ErrorInvalidArgs                          = errors.New("invalid arguments for command")
+	ErrorInvalidArgsMissingOpeningParantheses = errors.New("missing opening paranthesis for argument list")
+	ErrorInvalidArgsMissingClosingParantheses = errors.New("missing closing paranthesis for argument list")
+)
+
+type ParseError struct {
+	Err          error
+	LineNumber   int
+	ColumnNumber int
+	Line         string
+}
+
+func (e ParseError) Error() string {
+	return e.Err.Error()
+}
+
+func (e ParseError) Format() string {
+	// Create the caret pointer line
+	caret := strings.Repeat(" ", e.ColumnNumber-1) + "^"
+
+	return fmt.Sprintf("%s\n> %2d | %s\n       %s", e.Err.Error(), e.LineNumber, e.Line, caret)
+}
+
+type InlineReference struct {
+	// The command used
+	Command InlineCommand
+	// Arguments passed to the command
+	Args []string
+	// Line number where the reference was found
+	LineNumber int
+}
+
+type FileCommandArgs struct {
+	SpecFile string
+}
+
+type UrlCommandArgs struct {
+	Url string
+}
+
+type RfcCommandArgs struct {
+	Rfc int
+}
+
+// argString is a parenthesized enclosed string containing a number of arguments, potentially with additional
+// text after the closing parenthesis. Function arguments cannot contain the closing parenthesis character.
+// Examples:
+// (hello)
+// (./some/file.txt) some other text
+// (123, hello)
+func consumeCommandArgs(argString string) ([]string, error) {
+	if len(argString) == 0 {
+		return nil, ErrorInvalidArgsMissingOpeningParantheses
+	}
+	if argString[0] != '(' {
+		return nil, ErrorInvalidArgsMissingOpeningParantheses
+	}
+	endIndex := strings.Index(argString, ")")
+	if endIndex == -1 {
+		return nil, ErrorInvalidArgsMissingClosingParantheses
+	}
+	args := strings.Split(argString[1:endIndex], ",")
+	for i, arg := range args {
+		args[i] = strings.TrimSpace(arg)
+	}
+	return args, nil
+}
+
+func consumeCommandName(commandArgs string) (InlineCommand, string) {
+	if len(commandArgs) == 0 || commandArgs[0] != ':' {
+		// A colon is required to delineate the command from the prefix (i.e. semcheck:command)
+		return Invalid, ""
+	}
+
+	commandArgs = commandArgs[1:]
+
+	if strings.HasPrefix(commandArgs, "file") {
+		return File, commandArgs[4:]
+	} else if strings.HasPrefix(commandArgs, "rfc") {
+		return RFC, commandArgs[3:]
+	} else if strings.HasPrefix(commandArgs, "url") {
+		return URL, commandArgs[3:]
+	}
+	return Invalid, ""
+}
+
+func FindReferences(document string) ([]InlineReference, *ParseError) {
+	lines := strings.Split(document, "\n")
+	refs := make([]InlineReference, 0)
+
+	for lineNumber, line := range lines {
+		index := strings.Index(line, semcheckPrefix)
+		if index == -1 {
+			continue
+		}
+
+		command, argString := consumeCommandName(line[index+len(semcheckPrefix):])
+		if command == Invalid {
+			return nil, &ParseError{
+				Err:          ErrorInvalidCommand,
+				LineNumber:   lineNumber + 1,
+				ColumnNumber: index + len(semcheckPrefix) + 1,
+				Line:         line,
+			}
+		}
+
+		args, err := consumeCommandArgs(argString)
+
+		if err != nil {
+			return nil, &ParseError{
+				Err:          err,
+				LineNumber:   lineNumber + 1,
+				ColumnNumber: index + len(semcheckPrefix) + len(command) + 1,
+				Line:         line,
+			}
+		}
+
+		refs = append(refs, InlineReference{
+			Command:    command,
+			Args:       args,
+			LineNumber: lineNumber + 1,
+		})
+	}
+	return refs, nil
+}

--- a/internal/inline/parser_test.go
+++ b/internal/inline/parser_test.go
@@ -78,20 +78,12 @@ func TestErrorsFindReferences(t *testing.T) {
 			expected: InlineError{Err: ErrorInvalidArgsMissingClosingParantheses, LineNumber: 1},
 		},
 		{
-			input:    "// semcheck(args broken\n",
-			expected: InlineError{Err: ErrorInvalidCommand, LineNumber: 1},
-		},
-		{
 			input:    "// semcheck:file\n",
 			expected: InlineError{Err: ErrorInvalidArgsMissingOpeningParantheses, LineNumber: 1},
 		},
 		{
 			input:    "// semcheck:rfc 123\n",
 			expected: InlineError{Err: ErrorInvalidArgsMissingOpeningParantheses, LineNumber: 1},
-		},
-		{
-			input:    "// semcheck\n",
-			expected: InlineError{Err: ErrorInvalidCommand, LineNumber: 1},
 		},
 		{
 			input:    "// semcheck:file()",
@@ -122,27 +114,29 @@ func TestErrorsFindReferences(t *testing.T) {
 			expected: InlineError{Err: ErrorInvalidArgsURL, LineNumber: 1},
 		},
 		{
-			input:    "// semcheck:url(ftp://example.com)",
+			input:    "semcheck:url(ftp://example.com)",
 			expected: InlineError{Err: ErrorInvalidArgsURL, LineNumber: 1},
 		},
 	}
 
 	for _, tc := range cases {
-		_, parseErrors := FindReferences(tc.input)
+		t.Run(tc.input, func(t *testing.T) {
+			_, parseErrors := FindReferences(tc.input)
 
-		if len(parseErrors) == 0 {
-			t.Errorf("Expected error, got nothing")
-			continue
-		}
+			if len(parseErrors) == 0 {
+				t.Errorf("Expected error, got nothing")
+				return
+			}
 
-		// Check first error matches expected
-		err := parseErrors[0]
-		if err.Err != tc.expected.Err {
-			t.Errorf("Expected Error  %s, got %s", tc.expected.Err, err.Err)
-		}
-		if err.LineNumber != tc.expected.LineNumber {
-			t.Errorf("Expected LineNumber %d, got %d", tc.expected.LineNumber, err.LineNumber)
-		}
-		// fmt.Printf("Error: %s\n", err.Format())
+			// Check first error matches expected
+			err := parseErrors[0]
+			if err.Err != tc.expected.Err {
+				t.Errorf("Expected Error  %s, got %s", tc.expected.Err, err.Err)
+			}
+			if err.LineNumber != tc.expected.LineNumber {
+				t.Errorf("Expected LineNumber %d, got %d", tc.expected.LineNumber, err.LineNumber)
+			}
+			// fmt.Printf("Error: %s\n", err.Format())
+		})
 	}
 }

--- a/internal/inline/parser_test.go
+++ b/internal/inline/parser_test.go
@@ -1,0 +1,118 @@
+package inline
+
+import (
+	"testing"
+)
+
+func TestFindReferences(t *testing.T) {
+
+	cases := []struct {
+		input    string
+		expected []InlineReference
+	}{
+		{
+			input:    "// semcheck:file(./some-file.md)\n",
+			expected: []InlineReference{{Command: File, Args: []string{"./some-file.md"}, LineNumber: 1}},
+		},
+		{
+			input:    "semcheck:rfc(123) some other text\n",
+			expected: []InlineReference{{Command: RFC, Args: []string{"123"}, LineNumber: 1}},
+		},
+		{
+			input:    "semcheck:url(https://example.com/) some other text\n",
+			expected: []InlineReference{{Command: URL, Args: []string{"https://example.com/"}, LineNumber: 1}},
+		},
+		{
+			input:    "Multi Line \n  // semcheck:url(https://example.com/) \n some other text\n",
+			expected: []InlineReference{{Command: URL, Args: []string{"https://example.com/"}, LineNumber: 2}},
+		},
+		{
+			input:    "semcheck:rfc(123, another)",
+			expected: []InlineReference{{Command: RFC, Args: []string{"123", "another"}, LineNumber: 1}},
+		},
+	}
+
+	for _, tc := range cases {
+		refs, err := FindReferences(tc.input)
+
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		if len(refs) != len(tc.expected) {
+			t.Errorf("Expected %d references, got %d", len(tc.expected), len(refs))
+		}
+
+		for i, ref := range refs {
+			if ref.Command != tc.expected[i].Command {
+				t.Errorf("Expected command %s, got %s", tc.expected[i].Command, ref.Command)
+			}
+			if len(ref.Args) != len(tc.expected[i].Args) {
+				t.Errorf("Expected %d arguments, got %d", len(tc.expected[i].Args), len(ref.Args))
+			}
+			for j, arg := range ref.Args {
+				if arg != tc.expected[i].Args[j] {
+					t.Errorf("Expected argument %s, got %s", tc.expected[i].Args[j], arg)
+				}
+			}
+			if ref.LineNumber != tc.expected[i].LineNumber {
+				t.Errorf("Expected line number %d, got %d", tc.expected[i].LineNumber, ref.LineNumber)
+			}
+		}
+	}
+
+}
+
+func TestErrorsFindReferences(t *testing.T) {
+
+	cases := []struct {
+		input    string
+		expected ParseError
+	}{
+		{
+			input:    "// semcheck:invalidcommand(./some-file.md)\n",
+			expected: ParseError{Err: ErrorInvalidCommand, LineNumber: 1},
+		},
+		{
+			input:    "Multiple Lines \n// semcheck:invalidcommand(./some-file.md)\n",
+			expected: ParseError{Err: ErrorInvalidCommand, LineNumber: 2},
+		},
+		{
+			input:    "// semcheck:file(args broken\n",
+			expected: ParseError{Err: ErrorInvalidArgsMissingClosingParantheses, LineNumber: 1},
+		},
+		{
+			input:    "// semcheck(args broken\n",
+			expected: ParseError{Err: ErrorInvalidCommand, LineNumber: 1},
+		},
+		{
+			input:    "// semcheck:file\n",
+			expected: ParseError{Err: ErrorInvalidArgsMissingOpeningParantheses, LineNumber: 1},
+		},
+		{
+			input:    "// semcheck:rfc 123\n",
+			expected: ParseError{Err: ErrorInvalidArgsMissingOpeningParantheses, LineNumber: 1},
+		},
+		{
+			input:    "// semcheck\n",
+			expected: ParseError{Err: ErrorInvalidCommand, LineNumber: 1},
+		},
+	}
+
+	for _, tc := range cases {
+		_, err := FindReferences(tc.input)
+
+		if err == nil {
+			t.Errorf("Expected error, got nothing")
+			continue
+		}
+
+		if err.Err != tc.expected.Err {
+			t.Errorf("Expected Error  %s, got %s", tc.expected.Err, err.Err)
+		}
+		if err.LineNumber != tc.expected.LineNumber {
+			t.Errorf("Expected LineNumber %d, got %d", tc.expected.LineNumber, err.LineNumber)
+		}
+		// fmt.Printf("Error: %s\n", err.Format())
+	}
+}

--- a/internal/inline/parser_test.go
+++ b/internal/inline/parser_test.go
@@ -33,10 +33,10 @@ func TestFindReferences(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		refs, err := FindReferences(tc.input)
+		refs, parseErrors := FindReferences(tc.input)
 
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
+		if len(parseErrors) > 0 {
+			t.Errorf("Unexpected errors: %v", parseErrors)
 		}
 
 		if len(refs) != len(tc.expected) {
@@ -97,16 +97,22 @@ func TestErrorsFindReferences(t *testing.T) {
 			input:    "// semcheck\n",
 			expected: ParseError{Err: ErrorInvalidCommand, LineNumber: 1},
 		},
+		{
+			input:    "// semcheck:file()",
+			expected: ParseError{Err: ErrorInvalidArgsMissingArguments, LineNumber: 1},
+		},
 	}
 
 	for _, tc := range cases {
-		_, err := FindReferences(tc.input)
+		_, parseErrors := FindReferences(tc.input)
 
-		if err == nil {
+		if len(parseErrors) == 0 {
 			t.Errorf("Expected error, got nothing")
 			continue
 		}
 
+		// Check first error matches expected
+		err := parseErrors[0]
 		if err.Err != tc.expected.Err {
 			t.Errorf("Expected Error  %s, got %s", tc.expected.Err, err.Err)
 		}

--- a/internal/processor/git_test.go
+++ b/internal/processor/git_test.go
@@ -1,0 +1,78 @@
+package processor
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestGit(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cmd := exec.Command("git", "init")
+	cmd.Dir = tmpDir
+	err := cmd.Run()
+
+	if err != nil {
+		t.Fatalf("Failed to initialize git repository: %v", err)
+	}
+
+	t.Run("test staging files", func(t *testing.T) {
+		files := GetStagedFiles(tmpDir)
+		if len(files) != 0 {
+			t.Errorf("expected no staged files, got %v", files)
+		}
+
+		err = os.WriteFile(filepath.Join(tmpDir, "test.txt"), []byte("test content"), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		cmd = exec.Command("git", "add", "test.txt")
+		cmd.Dir = tmpDir
+		err = cmd.Run()
+
+		if err != nil {
+			t.Fatalf("Failed to stage file: %v", err)
+		}
+
+		files = GetStagedFiles(tmpDir)
+		if len(files) != 1 {
+			t.Errorf("expected 1 staged file, got %v", files)
+		}
+		if files[0] != "test.txt" {
+			t.Errorf("expected file name 'test.txt', got %s", files[0])
+		}
+	})
+
+	t.Run("test gitignore file loading", func(t *testing.T) {
+		files, err := LoadGitignore(tmpDir)
+
+		if err != nil {
+			t.Fatalf("Failed to load gitignore file: %v", err)
+		}
+
+		if files != nil {
+			t.Fatalf("expected no gitignore files, got %v", files)
+		}
+
+		err = os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("ola"), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create gitignore file: %v", err)
+		}
+
+		files, err = LoadGitignore(tmpDir)
+		if err != nil {
+			t.Fatalf("Failed to load gitignore file: %v", err)
+		}
+
+		if len(files) != 1 {
+			t.Errorf("expected 1 gitignore file, got %v", files)
+		}
+		if files[0] != "ola" {
+			t.Errorf("expected file name 'ola', got %s", files[0])
+		}
+
+	})
+}

--- a/internal/processor/matcher.go
+++ b/internal/processor/matcher.go
@@ -316,7 +316,7 @@ func (m *Matcher) matchFile(filePath string) []MatcherResult {
 			IgnoreReason: IgnoreReasonNone,
 		})
 		results = append(results, MatcherResult{
-			Path:         NormalizePath(ref.Args[0]), // TODO(doesn't work for rfc's just yet)
+			Path:         NormalizePath(ref.Args[0]),
 			Type:         FileTypeSpec,
 			RuleName:     "inline-ref",
 			IgnoreReason: IgnoreReasonNone,

--- a/internal/processor/matcher_test.go
+++ b/internal/processor/matcher_test.go
@@ -43,8 +43,8 @@ temp/
 	}
 
 	expectedRules := []string{"*.log", "temp/", ".DS_Store"}
-	if !reflect.DeepEqual(matcher.gitignoreRules, expectedRules) {
-		t.Errorf("Expected gitignore rules %v, got %v", expectedRules, matcher.gitignoreRules)
+	if !reflect.DeepEqual(matcher.ignoreRules, expectedRules) {
+		t.Errorf("Expected gitignore rules %v, got %v", expectedRules, matcher.ignoreRules)
 	}
 }
 
@@ -137,7 +137,7 @@ func TestMatcher_matchesPattern(t *testing.T) {
 
 func TestMatcher_matchesPatterns(t *testing.T) {
 	matcher := &Matcher{
-		gitignoreRules: []string{"*.log", "temp/", ".DS_Store"},
+		ignoreRules: []string{"*.log", "temp/", ".DS_Store"},
 	}
 
 	tests := []struct {
@@ -169,7 +169,7 @@ func TestMatcher_matchesPatterns(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := MatchesPatterns(tt.filePath, matcher.gitignoreRules)
+			result := MatchesPatterns(tt.filePath, matcher.ignoreRules)
 			if result != tt.expected {
 				t.Errorf("MatchesPatterns(%q, gitignore) = %v, expected %v", tt.filePath, result, tt.expected)
 			}
@@ -197,8 +197,8 @@ func TestMatcher_matchFile(t *testing.T) {
 	}
 
 	matcher := &Matcher{
-		config:         cfg,
-		gitignoreRules: []string{"*.log"},
+		config:      cfg,
+		ignoreRules: []string{"*.log"},
 	}
 
 	tests := []struct {

--- a/internal/processor/matcher_test.go
+++ b/internal/processor/matcher_test.go
@@ -49,7 +49,6 @@ temp/
 }
 
 func TestMatcher_matchesPattern(t *testing.T) {
-	matcher := &Matcher{}
 
 	tests := []struct {
 		name     string
@@ -128,9 +127,9 @@ func TestMatcher_matchesPattern(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := matcher.matchesPattern(tt.filePath, tt.pattern)
+			result := MatchesPattern(tt.filePath, tt.pattern)
 			if result != tt.expected {
-				t.Errorf("matchesPattern(%q, %q) = %v, expected %v", tt.filePath, tt.pattern, result, tt.expected)
+				t.Errorf("MatchesPattern(%q, %q) = %v, expected %v", tt.filePath, tt.pattern, result, tt.expected)
 			}
 		})
 	}
@@ -170,9 +169,9 @@ func TestMatcher_matchesPatterns(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := matcher.matchesPatterns(tt.filePath, matcher.gitignoreRules)
+			result := MatchesPatterns(tt.filePath, matcher.gitignoreRules)
 			if result != tt.expected {
-				t.Errorf("matchesPatterns(%q, gitignore) = %v, expected %v", tt.filePath, result, tt.expected)
+				t.Errorf("MatchesPatterns(%q, gitignore) = %v, expected %v", tt.filePath, result, tt.expected)
 			}
 		})
 	}

--- a/internal/processor/patterns.go
+++ b/internal/processor/patterns.go
@@ -1,0 +1,125 @@
+package processor
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// MatchesPatterns checks if a file path matches any of the given patterns
+func MatchesPatterns(filePath string, patterns []string) bool {
+	for _, pattern := range patterns {
+		if MatchesPattern(filePath, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchesPattern checks if a file path matches a single pattern
+func MatchesPattern(filePath, pattern string) bool {
+	// Normalize both file path and pattern by removing ./ prefix
+	const relativePrefixLen = len("./")
+	if strings.HasPrefix(pattern, "./") {
+		pattern = pattern[relativePrefixLen:]
+	}
+	if strings.HasPrefix(filePath, "./") {
+		filePath = filePath[relativePrefixLen:]
+	}
+
+	// Handle exact matches
+	if pattern == filePath {
+		return true
+	}
+
+	// Handle simple glob patterns
+	matched, err := filepath.Match(pattern, filePath)
+	if err == nil && matched {
+		return true
+	}
+
+	// Handle glob patterns with **
+	if strings.Contains(pattern, "**") {
+		return matchesGlobPattern(filePath, pattern)
+	}
+
+	// Handle directory-based patterns
+	if strings.Contains(pattern, "/") {
+		return matchesPathPattern(filePath, pattern)
+	}
+
+	return false
+}
+
+// matchesGlobPattern handles ** glob patterns
+func matchesGlobPattern(filePath, pattern string) bool {
+	// Handle patterns like **/.git, **/.DS_Store
+	if strings.HasPrefix(pattern, "**/") {
+		suffix := pattern[3:]
+		// Check if file matches suffix directly (for root level files)
+		matched, _ := filepath.Match(suffix, filePath)
+		return matched ||
+			strings.HasSuffix(filePath, suffix) ||
+			strings.Contains(filePath, "/"+suffix)
+	}
+
+	// Handle patterns like .git/**, temp/**
+	if strings.HasSuffix(pattern, "/**") {
+		prefix := pattern[:len(pattern)-3]
+		return strings.HasPrefix(filePath, prefix+"/") ||
+			strings.Contains(filePath, "/"+prefix+"/") ||
+			strings.HasPrefix(filePath, prefix)
+	}
+
+	// For patterns with ** in the middle
+	if strings.Contains(pattern, "**/") {
+		parts := strings.Split(pattern, "**/")
+		if len(parts) == 2 {
+			hasPrefix := strings.HasPrefix(filePath, parts[0])
+			// For the suffix, we need to match it as a pattern, not a literal string
+			if hasPrefix {
+				// Extract the part of the filePath after the prefix
+				remaining := filePath[len(parts[0]):]
+				// Check if the remaining part matches the suffix pattern
+				matched, _ := filepath.Match(parts[1], remaining)
+				if matched {
+					return true
+				}
+				// Also check if any subdirectory matches
+				if strings.Contains(remaining, "/") {
+					pathParts := strings.Split(remaining, "/")
+					for i := range pathParts {
+						subPath := strings.Join(pathParts[i:], "/")
+						if matched, _ := filepath.Match(parts[1], subPath); matched {
+							return true
+						}
+					}
+				}
+			}
+			return false
+		}
+	}
+
+	return false
+}
+
+// matchesPathPattern handles directory-based patterns
+func matchesPathPattern(filePath, pattern string) bool {
+	// Handle patterns with directory separators
+	matched, err := filepath.Match(pattern, filePath)
+	if err != nil {
+		return false
+	}
+	if matched {
+		return true
+	}
+
+	// For simple directory patterns like "temp/"
+	if strings.HasSuffix(pattern, "/") {
+		dirName := strings.TrimSuffix(pattern, "/")
+		return strings.HasPrefix(filePath, pattern) ||
+			strings.Contains(filePath, "/"+pattern) ||
+			strings.HasPrefix(filePath, dirName+"/")
+	}
+
+	return false
+}

--- a/internal/processor/rule_builder.go
+++ b/internal/processor/rule_builder.go
@@ -1,0 +1,90 @@
+package processor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rejot-dev/semcheck/internal/inline"
+)
+
+var IgnoredPaths = []string{"**/.git",
+	"**/.svn",
+	"**/.hg",
+	"**/.jj",
+	"**/CVS",
+	"**/.DS_Store",
+	"**/Thumbs.db",
+	"**/.classpath",
+	"**/.settings"}
+
+func FindAllInlineReferences(workingDir string) (map[NormalizedPath][]inline.InlineReference, error) {
+	// Traverse all files in the working directory, read them, and collect inline spec references
+	// Skip files in the tree that are ignored by Gitignore rules, or mentioned in IgnorePaths
+	gitIgnoreRules, err := LoadGitignore(workingDir)
+	if err != nil {
+		return nil, err
+	}
+
+	semIgnoreRules, err := LoadSemignore(workingDir)
+	if err != nil {
+		return nil, err
+	}
+
+	allIgnoredPatterns := append(gitIgnoreRules, IgnoredPaths...)
+	allIgnoredPatterns = append(allIgnoredPatterns, semIgnoreRules...)
+
+	allReferences := make(map[NormalizedPath][]inline.InlineReference)
+
+	err = filepath.WalkDir(workingDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories
+		if d.IsDir() {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(workingDir, path)
+		if err != nil {
+			return err
+		}
+
+		// Check if file should be ignored
+		if MatchesPatterns(relPath, allIgnoredPatterns) {
+			return nil // Skip this file
+		}
+
+		// Read file content
+		content, err := os.ReadFile(path)
+		if err != nil {
+			// Skip files that cannot be read (e.g., binary files, permission issues)
+			return nil
+		}
+
+		// Parse file for inline references
+		refs, parseErrors := inline.FindReferences(string(content))
+
+		for _, parseError := range parseErrors {
+			// Log warnings for Argument errors
+			if parseError.Err != inline.ErrorInvalidCommand {
+				fmt.Fprintf(os.Stderr, "Warning: failed to parse inline reference in %s: %s\n", relPath, parseError.Format())
+			}
+		}
+
+		// Store references grouped by file path
+		if len(refs) > 0 {
+			normalizedPath := NormalizePath(relPath)
+			allReferences[normalizedPath] = refs
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to traverse directory: %w", err)
+	}
+
+	return allReferences, nil
+}

--- a/internal/processor/rule_builder.go
+++ b/internal/processor/rule_builder.go
@@ -56,22 +56,7 @@ func FindAllInlineReferences(workingDir string) (map[NormalizedPath][]inline.Inl
 			return nil // Skip this file
 		}
 
-		// Read file content
-		content, err := os.ReadFile(path)
-		if err != nil {
-			// Skip files that cannot be read (e.g., binary files, permission issues)
-			return nil
-		}
-
-		// Parse file for inline references
-		refs, parseErrors := inline.FindReferences(string(content))
-
-		for _, parseError := range parseErrors {
-			// Log warnings for Argument errors
-			if parseError.Err != inline.ErrorInvalidCommand {
-				fmt.Fprintf(os.Stderr, "Warning: failed to parse inline reference in %s: %s\n", relPath, parseError.Format())
-			}
-		}
+		refs := FindInlineReferencesInFile(path)
 
 		// Store references grouped by file path
 		if len(refs) > 0 {
@@ -87,4 +72,24 @@ func FindAllInlineReferences(workingDir string) (map[NormalizedPath][]inline.Inl
 	}
 
 	return allReferences, nil
+}
+
+func FindInlineReferencesInFile(path string) []inline.InlineReference {
+	content, err := os.ReadFile(path)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not read file, won't check for inline spec references: %s\n", path)
+		return nil
+	}
+
+	// Parse file for inline references
+	refs, parseErrors := inline.FindReferences(string(content))
+
+	for _, parseError := range parseErrors {
+		// Log warnings for Argument errors
+		if parseError.Err != inline.ErrorInvalidCommand {
+			fmt.Fprintf(os.Stderr, "Warning: failed to parse inline reference in %s: %s\n", path, parseError.Format())
+		}
+	}
+	return refs
 }

--- a/internal/processor/rule_builder.go
+++ b/internal/processor/rule_builder.go
@@ -83,12 +83,12 @@ func FindInlineReferencesInFile(path string) []inline.InlineReference {
 	}
 
 	// Parse file for inline references
-	refs, parseErrors := inline.FindReferences(string(content))
+	refs, inlineErrors := inline.FindReferences(string(content))
 
-	for _, parseError := range parseErrors {
-		// Log warnings for Argument errors
+	for _, parseError := range inlineErrors {
+		// Log warnings for argument errors only, ignore the rest
 		if parseError.Err != inline.ErrorInvalidCommand {
-			fmt.Fprintf(os.Stderr, "Warning: failed to parse inline reference in %s: %s\n", path, parseError.Format())
+			fmt.Fprintf(os.Stderr, "Warning: failed to process inline reference in %s: %s\n", path, parseError.Format())
 		}
 	}
 	return refs

--- a/internal/processor/rule_builder_test.go
+++ b/internal/processor/rule_builder_test.go
@@ -1,0 +1,77 @@
+package processor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rejot-dev/semcheck/internal/inline"
+)
+
+func TestFindAllInlineReferences(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+
+	// Create test files with inline references
+	testFile1 := filepath.Join(tmpDir, "test1.go")
+	testContent1 := `package main
+
+// This is a test file
+// semcheck:file(./specs/api.md)
+func main() {
+	// semcheck:rfc(1234)
+	println("hello")
+}`
+
+	err := os.WriteFile(testFile1, []byte(testContent1), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	testFile2 := filepath.Join(tmpDir, "test2.go")
+	testContent2 := `package util
+
+// semcheck:url(https://example.com)
+func helper() {
+}`
+
+	err = os.WriteFile(testFile2, []byte(testContent2), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Call FindAllInlineReferences
+	result, err := FindAllInlineReferences(tmpDir)
+	if err != nil {
+		t.Fatalf("FindAllInlineReferences failed: %v", err)
+	}
+
+	// Verify results
+	if len(result) != 2 {
+		t.Errorf("Expected 2 files with references, got %d", len(result))
+	}
+
+	// Check test1.go references
+	test1Refs := result[NormalizedPath("test1.go")]
+	if len(test1Refs) != 2 {
+		t.Errorf("Expected 2 references in test1.go, got %d", len(test1Refs))
+	}
+
+	if test1Refs[0].Command != inline.File || len(test1Refs[0].Args) == 0 || test1Refs[0].Args[0] != "./specs/api.md" {
+		t.Errorf("Expected file reference to ./specs/api.md, got %v", test1Refs[0])
+	}
+
+	if test1Refs[1].Command != inline.RFC || len(test1Refs[1].Args) == 0 || test1Refs[1].Args[0] != "1234" {
+		t.Errorf("Expected RFC reference to 1234, got %v", test1Refs[1])
+	}
+
+	// Check test2.go references
+	test2Refs := result[NormalizedPath("test2.go")]
+	if len(test2Refs) != 1 {
+		t.Errorf("Expected 1 reference in test2.go, got %d", len(test2Refs))
+	}
+
+	if test2Refs[0].Command != inline.URL || len(test2Refs[0].Args) == 0 || test2Refs[0].Args[0] != "https://example.com" {
+		t.Errorf("Expected URL reference to https://example.com, got %v", test2Refs[0])
+	}
+}

--- a/semcheck.yaml
+++ b/semcheck.yaml
@@ -41,9 +41,6 @@ rules:
 
   - name: "Inline specification references"
     enabled: true
-    prompt: |
-      Check only that the format for the inline references is correct, how those references are handled
-      is not yet implemented.
     files:
       include:
         - "./internal/inline/*.go"

--- a/semcheck.yaml
+++ b/semcheck.yaml
@@ -37,6 +37,7 @@ rules:
       - path: "./Justfile" # Justfile instructions
       - path: "./cmd/cli/cli.go" # Command line interface
       - path: "./internal/providers/client.go" # Available providers
+      - path: "./internal/inline/parser.go"
     fail_on: "error"
 
   - name: "Inline specification references"

--- a/semcheck.yaml
+++ b/semcheck.yaml
@@ -38,3 +38,16 @@ rules:
       - path: "./cmd/cli/cli.go" # Command line interface
       - path: "./internal/providers/client.go" # Available providers
     fail_on: "error"
+
+  - name: "Inline specification references"
+    enabled: true
+    prompt: |
+      Check only that the format for the inline references is correct, how those references are handled
+      is not yet implemented.
+    files:
+      include:
+        - "./internal/inline/*.go"
+      exclude:
+        - "./internal/inline/*_test.go"
+    specs:
+      - path: "./specs/inline.md"

--- a/site/src/code-samples/config.yaml
+++ b/site/src/code-samples/config.yaml
@@ -1,7 +1,7 @@
 version: "1.0"
-provider: openai
-model: gpt-4.1
-api_key: ${OPENAI_API_KEY}
+provider: "anthropic"
+model: "claude-sonnet-4-0"
+api_key: "${ANTHROPIC_API_KEY}"
 
 rules:
   - name: api-compliance

--- a/site/src/components/quickstart.astro
+++ b/site/src/components/quickstart.astro
@@ -19,13 +19,41 @@ import runCode from "../code-samples/run.sh?raw";
     </div>
 
     <div class="space-y-4">
-      <h3 class="text-lg font-medium text-gray-900">Define Rules</h3>
+      <h3 class="text-lg font-medium text-gray-900">Link Specs to Implementation</h3>
       <p class="text-gray-600">
-        Rules tie specification files to implementation files. Semcheck invokes the LLM once per
-        rule, and in pre-commit mode, only for rules with modified files. For best results, try to
-        keep the number of files per rule small, LLMs perform best with focused context.
+        Semcheck supports two ways to link specifications to implementation files. Both can be used
+        together.
       </p>
-      <Code code={configCode} lang="yaml" />
+
+      <div class="space-y-3">
+        <h4 class="text-md font-medium text-gray-800">1. Inline spec references (recommended)</h4>
+        <p class="text-sm text-gray-600">
+          Link specifications directly in your code using special comment syntax:
+        </p>
+        <Code
+          code=`# semcheck:rfc(8259)
+class JsonParser:
+    def parse(self, data: bytes):
+        # ... implementation`
+          lang="python"
+        />
+        <p class="text-sm text-gray-600">Available commands:</p>
+        <Code
+          code=`semcheck:file(./local/spec.md)  # Link repo local files
+semcheck:url(https://example.com/docs/api)  # Link to remote documents
+semcheck:rfc(8259)  # Shorthand for linking to RFC documents on rfc-editor.org`
+          lang="python"
+        />
+      </div>
+
+      <div class="space-y-3">
+        <h4 class="text-md font-medium text-gray-800">2. Rules (advanced)</h4>
+        <p class="text-sm text-gray-600">
+          Define rules in your <code>semcheck.yaml</code> configuration that tie specification files
+          to implementation files:
+        </p>
+        <Code code={configCode} lang="yaml" />
+      </div>
     </div>
 
     <div class="space-y-4">

--- a/specs/inline.md
+++ b/specs/inline.md
@@ -6,7 +6,7 @@ Inline specification references allow developers to link specification files dir
 
 ## Syntax
 
-The inline specification reference uses a language-agnostic comment-based syntax:
+The inline specification reference uses a language-agnostic syntax and can be used within comments of your respective language.
 
 ```
 // semcheck:[command]([args])
@@ -65,12 +65,16 @@ Links to a document on the web.
 
 ### File Discovery
 1. During semcheck initialization, all files in the working directory are scanned
-2. Files in the following directories are ignored by default:
+2. Files matching the following patterns are ignored by default:
    - `**/.git`, `**/.svn`, `**/.hg`, `**/.jj`, `**/CVS` (version control)
    - `**/.DS_Store`, `**/Thumbs.db` (system files)
    - `**/.classpath`, `**/.settings` (IDE files)
-3. Files excluded by `.gitignore` or rule exclusion patterns are also skipped
+3. Files excluded by `.gitignore`, `.semignore`, or rule exclusion patterns are also skipped
 4. Each remaining file is parsed line-by-line for inline specification references
+
+#### Ignore Files
+- **`.gitignore`**: Standard Git ignore patterns are respected
+- **`.semignore`**: semcheck-specific ignore patterns using the same syntax as `.gitignore`
 
 ### Reference Resolution
 1. **File references**: Resolved relative to the working directory of where semcheck is running
@@ -107,7 +111,7 @@ class MyJsonParser:
 ### Syntax Validation
 - Command is one of  'file', 'rfc', 'url'
 - Arguments must be enclosed in parentheses
-- Multiple arguments separated by commas (future extension)
+- Multiple arguments separated by commas, with optional whitespace
 
 ### Path Validation
 - File paths are validated for existence during processing,

--- a/specs/inline.md
+++ b/specs/inline.md
@@ -26,7 +26,7 @@ Links to a local specification file.
 **Syntax**: `semcheck:file(path)`
 
 **Arguments**:
-- `path`: file relative path or repo relative path to a specification file, absolute paths starting with `/` consider the repo as the root directory. If not located inside a git repository, the CWD will be used as root.
+- `path`: file relative path to directory semcheck is running in.
 
 **Examples**:
 ```javascript

--- a/specs/inline.md
+++ b/specs/inline.md
@@ -1,0 +1,118 @@
+# Inline Specification References
+
+## Overview
+
+Inline specification references allow developers to link specification files directly from implementation files using special comment syntax. This feature enables granular specification-to-implementation mapping at the code level, complementing the global rule-based configuration.
+
+## Syntax
+
+The inline specification reference uses a language-agnostic comment-based syntax:
+
+```
+// semcheck:[command]([args])
+```
+
+### Components
+
+- **semcheck**: Required identifier (case-sensitive)
+- **:[command]**: Required command specifier
+- **([...args])**: Command arguments in parentheses
+
+### Supported Commands
+
+#### 1. file(path)
+Links to a local specification file.
+
+**Syntax**: `semcheck:file(path)`
+
+**Arguments**:
+- `path`: file relative path or repo relative path to a specification file, absolute paths starting with `/` consider the repo as the root directory. If not located inside a git repository, the CWD will be used as root.
+
+**Examples**:
+```javascript
+// semcheck:file(../specs/api.md)
+// semcheck:file(/specs/protocol.md)
+```
+
+#### 2. rfc(number)
+Links to an IETF RFC document.
+
+**Syntax**: `semcheck:rfc(number)`
+
+**Arguments**:
+- `number`: RFC number (e.g., 7946, 8259)
+
+**Examples**:
+```python
+# semcheck:rfc(8259)  # JSON specification
+# semcheck:rfc(7946)  # GeoJSON specification
+```
+
+#### 3. url(url)
+Links to a document on the web.
+
+**Syntax**: `semcheck:url(url)`
+
+**Arguments**:
+- `url`: URL of the document
+
+**Examples**:
+```python
+# semcheck:url(https://docs.anthropic.com/en/api/messages)
+```
+
+## Processing Behavior
+
+### File Discovery
+1. During semcheck initialization, all files in the working directory are scanned
+2. Files in the following directories are ignored by default:
+   - `**/.git`, `**/.svn`, `**/.hg`, `**/.jj`, `**/CVS` (version control)
+   - `**/.DS_Store`, `**/Thumbs.db` (system files)
+   - `**/.classpath`, `**/.settings` (IDE files)
+3. Files excluded by `.gitignore` or rule exclusion patterns are also skipped
+4. Each remaining file is parsed line-by-line for inline specification references
+
+### Reference Resolution
+1. **File references**: Resolved relative to the working directory of where semcheck is running
+2. **RFC references**: Fetched from `https://www.rfc-editor.org/rfc/rfc{number}.txt`
+3. **URL references**: Fetched from the provided URL
+4. Invalid references generate warnings but don't halt processing
+
+### Integration with Rules
+- Inline references are additive to configured rules in the semcheck config
+- Each pair of implementation file and specification file are considered an implicit semantic rule and will be checked independently, if multiple files reference the same specification, only one call to the LLM will be performed with all implementation files.
+
+## Examples
+
+```javascript
+// semcheck:file(./specs/user-api.md)
+class UserService {
+    // ... implementation
+}
+```
+
+```python
+# semcheck:rfc(8259)
+class MyJsonParser:
+
+    def __init__(self):
+        pass
+
+    def parse_from_string(self, data: str):
+        pass
+```
+
+## Validation Rules
+
+### Syntax Validation
+- Command is one of  'file', 'rfc', 'url'
+- Arguments must be enclosed in parentheses
+- Multiple arguments separated by commas (future extension)
+
+### Path Validation
+- File paths are validated for existence during processing,
+- urls and rfc are validated only for syntactic correctness
+
+### Error Handling
+- Malformed syntax generates warnings and are ignored
+- Missing local files fail semcheck

--- a/specs/semcheck.md
+++ b/specs/semcheck.md
@@ -77,8 +77,9 @@ temperature: 0.1
 # Default: true
 fail_on_issues: true
 
-# Checking rules configuration (REQUIRED)
+# Checking rules configuration (OPTIONAL)
 # Array of rules that define what to check and how
+# If no rules are provided, semcheck will only process inline specification references
 rules:
   - # Rule identifier (REQUIRED)
     # Used for logging, reporting, and selective rule execution
@@ -210,7 +211,7 @@ When you provide a list of files to semcheck, semcheck will automatically match 
 - `provider`: Must be "openai", "anthropic", "gemini", or "ollama"
 - `model`: Must be a valid model name for the selected provider
 - `api_key`: Required for cloud providers (openai, anthropic, gemini), optional for local providers (ollama)
-- `rules`: Must contain at least one rule object
+- `rules`: Optional array of rule objects. If empty or omitted, semcheck will only process inline specification references
 - `rules[].name`: Must be unique within the configuration
 - `rules[].files.include`: Must contain at least one pattern
 - `rules[].specs`: Must contain at least one specification


### PR DESCRIPTION
This PR adds inline specification references.

Example:

```python
# semcheck:rfc(8259)
class JsonParser:
    def parse(self, data: bytes):
        # ... implementation
```