### PR TITLE
Use anchors to link to specific parts of a structured specification document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ Changelog entries should be added to this file in reverse chronological order. O
 
 ## [Unreleased]
 
+### Added
+- **Anchor Support**: Added support for URL fragments/anchors for structured formats such as markdown and HTML. Include a subsection of your specification by using link fragment like `#section-3.1.1`. For HTML documents, this follows the same semantics as your browser targeting a section, for markdown you can use the header text as a link instead.
+- **Log Level CLI Option**: Added `--log-level` command line option to control logging verbosity (info, debug, error, warning)
+
+### Changed
+- **HTML Content Filtering**: Implemented content filtering to remove unwanted HTML elements (scripts, styles, forms, etc.) and attributes using allowlist approach
+- **Document Processing**: Updated implementation for downloading/reading specifications
+
 ## v1.1
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ semcheck:url(https://example.com/docs/api)  # Link to remote documents
 semcheck:rfc(8259)  # Shorthand for linking to RFC documents on rfc-editor.org
 ```
 
+#### Using Fragments/Anchors
+
+You can target specific sections of structured documents (HTML and Markdown) using URL fragments:
+
+```python
+# Link to a specific section in an HTML document
+# semcheck:url(https://www.rfc-editor.org/rfc/rfc7946.html#section-3.1.1)
+
+# Link to a specific section in a Markdown document using header text
+# semcheck:file(./docs/api-spec.md#authentication)
+
+# Works with RFC documents too
+# semcheck:rfc(8259#section1)
+```
+
+For HTML documents, fragments work the same way as browser navigation, they target elements with matching `id` or `name` attributes. For Markdown documents, you can use the header text as the fragment identifier (spaces and special characters are converted to anchor format).
+
 
 ### 2. Rules
 

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -27,6 +27,7 @@ var (
 	preCommit    = flag.Bool("pre-commit", false, "Runs semcheck on staged files")
 	initConfig   = flag.Bool("init", false, "create a semcheck.yaml file interactively")
 	githubOutput = flag.Bool("github-output", false, "output GitHub Actions annotations")
+	logLevel     = flag.String("log-level", "info", "set log level (info, debug, error, warning)")
 )
 
 var (
@@ -41,6 +42,23 @@ func Execute() error {
 	if *showHelp {
 		showUsage()
 		return nil
+	}
+
+	if *logLevel != "" {
+		switch *logLevel {
+		case "info":
+			log.SetLevel(log.InfoLevel)
+		case "debug":
+			log.SetLevel(log.DebugLevel)
+		case "error":
+			log.SetLevel(log.ErrorLevel)
+		case "warning":
+			log.SetLevel(log.WarnLevel)
+		default:
+			fmt.Fprintf(os.Stderr, "Invalid log level: %s\n", *logLevel)
+			return errors.New("invalid log level")
+		}
+
 	}
 
 	if *showVer {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/openai/openai-go v1.5.0
 	github.com/prathyushnallamothu/ollamago v1.0.0
 	github.com/yuin/goldmark v1.7.13
+	golang.org/x/net v0.34.0
 	google.golang.org/genai v1.13.0
 )
 
@@ -46,7 +47,6 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
-	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.21.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/invopop/jsonschema v0.13.0
 	github.com/openai/openai-go v1.5.0
 	github.com/prathyushnallamothu/ollamago v1.0.0
+	github.com/yuin/goldmark v1.7.13
 	google.golang.org/genai v1.13.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
+github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/inline/parser.go
+++ b/internal/inline/parser.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 )
@@ -157,11 +156,6 @@ func validateAndTransformArgs(command InlineCommand, args []string) ([]string, e
 	case File:
 		if len(args) != 1 {
 			return args, ErrorInvalidArgsNumber
-		}
-
-		// TODO: Consider moving this check outside of the parser
-		if _, err := os.Stat(args[0]); os.IsNotExist(err) {
-			return args, ErrorInvalidArgsMissingSpecFile
 		}
 
 		return args, nil

--- a/internal/inline/parser.go
+++ b/internal/inline/parser.go
@@ -164,13 +164,19 @@ func validateAndTransformArgs(command InlineCommand, args []string) ([]string, e
 			return args, ErrorInvalidArgsNumber
 		}
 
-		// Validate that the argument is a positive integer
-		rfcNumber, err := strconv.Atoi(args[0])
+		// Split off anchor from number
+		rfcParts := strings.Split(args[0], "#")
+		rfcNumber, err := strconv.Atoi(rfcParts[0])
 		if err != nil || rfcNumber <= 0 {
 			return args, ErrorInvalidArgsRFCNumber
 		}
 
-		args = []string{fmt.Sprintf("https://www.rfc-editor.org/rfc/rfc%d.txt", rfcNumber)}
+		anchor := ""
+		if len(rfcParts) > 1 && rfcParts[1] != "" {
+			anchor = "#" + rfcParts[1]
+		}
+
+		args = []string{fmt.Sprintf("https://datatracker.ietf.org/doc/html/rfc%d%s", rfcNumber, anchor)}
 
 		return args, nil
 	case URL:

--- a/internal/inline/parser_test.go
+++ b/internal/inline/parser_test.go
@@ -16,7 +16,11 @@ func TestFindReferences(t *testing.T) {
 		},
 		{
 			input:    "semcheck:rfc(123) some other text\n",
-			expected: []InlineReference{{Command: RFC, Args: []string{"https://www.rfc-editor.org/rfc/rfc123.txt"}, LineNumber: 1}},
+			expected: []InlineReference{{Command: RFC, Args: []string{"https://datatracker.ietf.org/doc/html/rfc123"}, LineNumber: 1}},
+		},
+		{
+			input:    "semcheck:rfc(123#section-1) some other text\n",
+			expected: []InlineReference{{Command: RFC, Args: []string{"https://datatracker.ietf.org/doc/html/rfc123#section-1"}, LineNumber: 1}},
 		},
 		{
 			input:    "semcheck:url(https://example.com/) some other text\n",

--- a/internal/processor/document_collector.go
+++ b/internal/processor/document_collector.go
@@ -28,7 +28,6 @@ var (
 	ErrorCollectingBadURL                         = errors.New("error collecting document, bad URL")
 	ErrorCollectingUnknownDocumentType            = errors.New("error collecting document, unknown document type")
 	ErrorCollectingNoDocumentParser               = errors.New("error collecting document, no document parser for document type")
-	ErrorLocalFileNoExtension                     = errors.New("error collecting document, local file has no extension")
 	ErrorAnchorNotSupportedOnUnstructuredDocument = errors.New("error collecting document, anchor not supported on unstructured document")
 	ErrorParsing                                  = errors.New("error parsing document")
 )
@@ -79,11 +78,6 @@ func collectLocalFile(path string) ([]byte, DocumentType, error) {
 		return nil, "", err
 	}
 	fileExtension := filepath.Ext(path)
-
-	if fileExtension == "" {
-		return nil, UNKNOWN, ErrorLocalFileNoExtension
-	}
-
 	return content, extensionToDocumentType(fileExtension), nil
 }
 
@@ -183,8 +177,8 @@ func CollectDocument(url *url.URL) (CollectedDocument, error) {
 	case TXT:
 		return UnstructuredDocument(content), nil
 	case UNKNOWN:
-		// Consider to return an unstructured document as fallback
-		return CollectedDocument{}, ErrorCollectingUnknownDocumentType
+		// Return an unstructured document as fallback
+		return UnstructuredDocument(content), nil
 	default:
 		return CollectedDocument{}, ErrorCollectingNoDocumentParser
 	}

--- a/internal/processor/document_collector.go
+++ b/internal/processor/document_collector.go
@@ -1,0 +1,189 @@
+package processor
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/log"
+)
+
+type DocumentType string
+
+const (
+	Markdown = "md"
+	HTML     = "html"
+	TXT      = "txt"
+	PDF      = "pdf"
+	UNKNOWN  = "unkown"
+)
+
+var (
+	ErrorCollectingBadURL                         = errors.New("error collecting document, bad URL")
+	ErrorCollectingUnknownDocumentType            = errors.New("error collecting document, unknown document type")
+	ErrorCollectingNoDocumentParser               = errors.New("error collecting document, no document parser for document type")
+	ErrorLocalFileNoExtension                     = errors.New("error collecting document, local file has no extension")
+	ErrorAnchorNotSupportedOnUnstructuredDocument = errors.New("error collecting document, anchor not supported on unstructured document")
+	ErrorParsing                                  = errors.New("error parsing document")
+)
+
+// TODO: Rename, if type == TXT then it is actually unstructured
+type StructuredDocument struct {
+	Type    DocumentType
+	content []byte
+	anchors map[string]string
+}
+
+func UnstructuredDocument(content []byte) StructuredDocument {
+	return StructuredDocument{
+		Type:    TXT,
+		content: content,
+		anchors: make(map[string]string),
+	}
+}
+
+func (s *StructuredDocument) GetSubsection(anchor string) string {
+	return s.anchors[anchor]
+}
+
+type DocumentParser interface {
+	Parse(content []byte) (StructuredDocument, error)
+}
+
+func collectLocalFile(path string) ([]byte, DocumentType, error) {
+	// Read file content
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, "", err
+	}
+	fileExtension := filepath.Ext(path)
+
+	if fileExtension == "" {
+		return nil, UNKNOWN, ErrorLocalFileNoExtension
+	}
+
+	return content, extensionToDocumentType(fileExtension), nil
+}
+
+func extensionToDocumentType(ext string) DocumentType {
+	switch ext {
+	case ".md":
+		return Markdown
+	case ".html":
+		return HTML
+	case ".txt":
+		return TXT
+	case ".pdf":
+		return PDF
+	default:
+		return UNKNOWN
+	}
+}
+
+func mimeToDocumentType(headerString string) DocumentType {
+	if headerString == "" {
+		return UNKNOWN
+	}
+
+	// mime-type = type "/" [tree "."] subtype ["+" suffix]* [";" parameter];
+	// Example: text/plain; charset=utf-8
+	headerParts := strings.Split(headerString, ";")
+
+	log.Debug("Mimetype received", "mime", headerParts[0])
+
+	switch headerParts[0] {
+	case "text/html":
+		return HTML
+	case "text/plain":
+		return TXT
+	case "application/pdf":
+		return PDF
+	default:
+		return UNKNOWN
+	}
+}
+
+func collectRemoteFile(url *url.URL) ([]byte, DocumentType, error) {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	resp, err := client.Get(url.String())
+
+	if err != nil {
+		return nil, UNKNOWN, fmt.Errorf("failed to fetch URL %s: %w", url, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, UNKNOWN, fmt.Errorf("failed to fetch URL %s: HTTP %d %s", url, resp.StatusCode, resp.Status)
+	}
+
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, UNKNOWN, fmt.Errorf("failed to read content from URL %s: %w", url, err)
+	}
+
+	docType := mimeToDocumentType(resp.Header.Get("Content-Type"))
+
+	if docType == TXT {
+		// Markdown files will have mimeType text/plain, see if we can detect from the extension
+		// if it's actually markdown
+		if url.Path != "" && strings.HasSuffix(url.Path, ".md") {
+			docType = Markdown
+		}
+	}
+
+	return content, docType, nil
+}
+
+func CollectDocument(path string) (structuredDoc StructuredDocument, anchor string, err error) {
+	parsedUrl, err := url.Parse(path)
+
+	if err != nil {
+		return StructuredDocument{}, "", ErrorCollectingBadURL
+	}
+
+	anchor = parsedUrl.Fragment
+
+	var content []byte
+	var docType DocumentType
+
+	if parsedUrl.Scheme == "" || parsedUrl.Scheme == "file" {
+		log.Debug("Collecting local file", "path", path)
+		content, docType, err = collectLocalFile(path)
+	} else {
+		log.Debug("Collecting remote file", "path", path)
+		content, docType, err = collectRemoteFile(parsedUrl)
+	}
+
+	if err != nil {
+		return StructuredDocument{}, anchor, err
+	}
+
+	var parser DocumentParser
+
+	switch docType {
+	case Markdown:
+		parser = NewMarkdownParser()
+	case TXT:
+		if anchor != "" {
+			return StructuredDocument{}, anchor, ErrorAnchorNotSupportedOnUnstructuredDocument
+		}
+		return UnstructuredDocument(content), "", nil
+	case UNKNOWN:
+		// Consider to return an unstructured document as fallback
+		return StructuredDocument{}, anchor, ErrorCollectingUnknownDocumentType
+	default:
+		return StructuredDocument{}, anchor, ErrorCollectingNoDocumentParser
+	}
+
+	structuredDoc, err = parser.Parse(content)
+
+	return structuredDoc, anchor, err
+}

--- a/internal/processor/document_collector_test.go
+++ b/internal/processor/document_collector_test.go
@@ -73,10 +73,17 @@ func TestDocumentCollector(t *testing.T) {
 
 	t.Run("collect document with anchor", func(t *testing.T) {
 		parsedURL, _ := url.Parse("https://semcheck.ai#my-anchor")
-		_, err := CollectDocument(parsedURL)
-		// TODO: add test once implemented
-		if err != ErrorCollectingNoDocumentParser {
-			t.Errorf("Expected %v, got %v", ErrorCollectingNoDocumentParser, err)
+		doc, err := CollectDocument(parsedURL)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		if doc.Type != HTML {
+			t.Errorf("Expected docType html, got %s", doc.Type)
+		}
+
+		if !doc.IsStructuredDocument() {
+			t.Errorf("Expected structured document for HTML")
 		}
 	})
 }
@@ -144,6 +151,17 @@ func TestDocumentCollection(t *testing.T) {
 		_, err := dc.GetDocument("https://www.rfc-editor.org/rfc/rfc6762.txt#section-1")
 		if err != ErrorAnchorNotSupportedOnUnstructuredDocument {
 			t.Errorf("GetDocument() error is not the one expected = %v", err)
+		}
+	})
+
+	t.Run("anchors error on unstructureddocument collection", func(t *testing.T) {
+		content, err := dc.GetDocument("https://www.rfc-editor.org/rfc/rfc7946.html#section-1")
+		if err != nil {
+			t.Errorf("GetDocument() error = %v", err)
+		}
+
+		if len(content) < 1 {
+			t.Errorf("GetDocument() content length = %d, want > 0", len(content))
 		}
 	})
 }

--- a/internal/processor/document_collector_test.go
+++ b/internal/processor/document_collector_test.go
@@ -1,0 +1,97 @@
+package processor
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/charmbracelet/log"
+)
+
+func TestDocumentCollection(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+
+	t.Run("local file collection", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		testFile := filepath.Join(tmpDir, "spec.md")
+
+		content := []byte("# Spec\n hey")
+		err := os.WriteFile(testFile, content, 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		readContent, docType, err := collectLocalFile(string(testFile))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(readContent) != string(content) {
+			t.Errorf("Expected content %s, got %s", string(content), string(readContent))
+		}
+		if docType != Markdown {
+			t.Errorf("Expected docType markdown, got %s", docType)
+		}
+	})
+
+	t.Run("remote collection", func(t *testing.T) {
+		parsedUrl, _ := url.Parse("https://semcheck.ai")
+		_, docType, err := collectRemoteFile(parsedUrl)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if docType != HTML {
+			t.Errorf("Expected docType html, got %s", docType)
+		}
+	})
+
+	t.Run("collect unstructured document", func(t *testing.T) {
+		structuredDoc, anchor, err := CollectDocument("https://www.rfc-editor.org/rfc/rfc6762.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if structuredDoc.Type != TXT {
+			t.Errorf("Expected docType txt, got %s", structuredDoc.Type)
+		}
+		if anchor != "" {
+			t.Errorf("Expected anchor to be empty, got %s", anchor)
+		}
+	})
+
+	t.Run("collect unstructured document with anchor", func(t *testing.T) {
+		_, anchor, err := CollectDocument("https://www.rfc-editor.org/rfc/rfc6762.txt#section-1")
+		if anchor != "section-1" {
+			t.Errorf("Expected anchor to be section-1, got %s", anchor)
+		}
+
+		if err != ErrorAnchorNotSupportedOnUnstructuredDocument {
+			t.Errorf("Expected %v, got %v", ErrorAnchorNotSupportedOnUnstructuredDocument, err)
+		}
+	})
+
+	t.Run("collect remote markdown", func(t *testing.T) {
+		doc, anchor, err := CollectDocument("https://raw.githubusercontent.com/rejot-dev/semcheck/4d634dc6bfd7b5a00b98b2f862f2fd567b08919b/specs/semcheck.md")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if anchor != "" {
+			t.Errorf("Expected anchor to be empty, got %s", anchor)
+		}
+
+		if doc.Type != Markdown {
+			t.Errorf("Expected docType md, got %s", doc.Type)
+		}
+	})
+
+	t.Run("collect document with anchor", func(t *testing.T) {
+		_, _, err := CollectDocument("https://semcheck.ai#my-anchor")
+		// TODO: add test once implemented
+		if err != ErrorCollectingNoDocumentParser {
+			t.Errorf("Expected %v, got %v", ErrorCollectingNoDocumentParser, err)
+		}
+	})
+}

--- a/internal/processor/html_parser.go
+++ b/internal/processor/html_parser.go
@@ -1,0 +1,337 @@
+package processor
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+type htmlParser struct{}
+
+func NewHTMLParser() DocumentParser {
+	return &htmlParser{}
+}
+
+func (p *htmlParser) Parse(content []byte) (CollectedDocument, error) {
+	anchors := make(map[string]string)
+	source := string(content)
+
+	doc, err := html.Parse(strings.NewReader(source))
+	if err != nil {
+		return CollectedDocument{}, fmt.Errorf("failed to parse HTML: %w", err)
+	}
+
+	// Filter out unwanted elements before processing
+	filterUnwantedElements(doc)
+
+	// Traverse the HTML tree to find all elements with IDs or elements with names
+	// semcheck:url(https://html.spec.whatwg.org/multipage/browsing-the-web.html#select-the-indicated-part)
+	var traverse func(*html.Node)
+	traverse = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			// Check for ID attribute (any element can have an ID)
+			for _, attr := range n.Attr {
+				if attr.Key == "id" && attr.Val != "" {
+					// Get contextual content based on element type
+					htmlContent := getContextualContent(n)
+					anchors[attr.Val] = htmlContent
+					break
+				}
+			}
+
+			// Check for name attribute on anchor elements
+			if n.Data == "a" {
+				for _, attr := range n.Attr {
+					if attr.Key == "name" && attr.Val != "" {
+						// Get contextual content for anchor elements
+						htmlContent := getContextualContent(n)
+						anchors[attr.Val] = htmlContent
+						break
+					}
+				}
+			}
+		}
+
+		// Traverse children
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			traverse(c)
+		}
+	}
+
+	traverse(doc)
+
+	return CollectedDocument{
+		Type:    HTML,
+		content: content,
+		anchors: anchors,
+	}, nil
+}
+
+// renderNode converts an HTML node and its children back to HTML string
+func renderNode(n *html.Node) string {
+	var buf strings.Builder
+	_ = html.Render(&buf, n)
+	return buf.String()
+}
+
+// isUnwantedElement checks if the node is an element that should be filtered out
+func isUnwantedElement(n *html.Node) bool {
+	if n.Type != html.ElementNode {
+		return false
+	}
+
+	unwantedTags := map[string]bool{
+		"script":   true,
+		"style":    true,
+		"svg":      true,
+		"canvas":   true,
+		"audio":    true,
+		"video":    true,
+		"embed":    true,
+		"object":   true,
+		"iframe":   true,
+		"noscript": true,
+		"form":     true,
+		"input":    true,
+		"button":   true,
+		"select":   true,
+		"textarea": true,
+		"meta":     true,
+		"link":     true,
+		"base":     true,
+		"title":    true,
+		"head":     true,
+	}
+
+	return unwantedTags[n.Data]
+}
+
+// isAllowedAttribute checks if an attribute should be preserved
+func isAllowedAttribute(attrKey string) bool {
+	allowedAttrs := map[string]bool{
+		// Essential for anchoring and navigation
+		"id":   true,
+		"name": true,
+		"href": true,
+	}
+
+	return allowedAttrs[attrKey]
+}
+
+// filterAttributes removes unwanted attributes from an element, keeping only allowed ones
+func filterAttributes(n *html.Node) {
+	if n.Type != html.ElementNode {
+		return
+	}
+
+	var filteredAttrs []html.Attribute
+	for _, attr := range n.Attr {
+		if isAllowedAttribute(attr.Key) {
+			filteredAttrs = append(filteredAttrs, attr)
+		}
+	}
+	n.Attr = filteredAttrs
+}
+
+// filterUnwantedElements recursively removes unwanted elements and attributes from the HTML tree
+func filterUnwantedElements(n *html.Node) {
+	child := n.FirstChild
+	for child != nil {
+		next := child.NextSibling
+
+		if isUnwantedElement(child) {
+			// Remove the unwanted element
+			n.RemoveChild(child)
+		} else {
+			// Filter attributes from this element
+			filterAttributes(child)
+			// Recursively filter children
+			filterUnwantedElements(child)
+		}
+
+		child = next
+	}
+}
+
+// isHeadingElement checks if the node is a heading element (h1-h6)
+func isHeadingElement(n *html.Node) bool {
+	if n.Type != html.ElementNode {
+		return false
+	}
+	return n.Data == "h1" || n.Data == "h2" || n.Data == "h3" ||
+		n.Data == "h4" || n.Data == "h5" || n.Data == "h6"
+}
+
+// getHeadingLevel returns the numeric level of a heading (1-6), or 0 if not a heading
+func getHeadingLevel(n *html.Node) int {
+	if !isHeadingElement(n) {
+		return 0
+	}
+	switch n.Data {
+	case "h1":
+		return 1
+	case "h2":
+		return 2
+	case "h3":
+		return 3
+	case "h4":
+		return 4
+	case "h5":
+		return 5
+	case "h6":
+		return 6
+	default:
+		return 0
+	}
+}
+
+// isSectioningElement checks if the node is a sectioning element
+func isSectioningElement(n *html.Node) bool {
+	if n.Type != html.ElementNode {
+		return false
+	}
+	return n.Data == "section" || n.Data == "article" ||
+		n.Data == "aside" || n.Data == "nav" ||
+		n.Data == "main" || n.Data == "body"
+}
+
+// findNearestSectioningContainer traverses up the DOM to find the nearest sectioning container
+func findNearestSectioningContainer(n *html.Node) *html.Node {
+	current := n.Parent
+	for current != nil {
+		if isSectioningElement(current) {
+			return current
+		}
+		current = current.Parent
+	}
+	return nil // Should not happen since body is always a sectioning element
+}
+
+// collectContentFollowingElement collects content that follows the target element within its sectioning container
+func collectContentFollowingElement(targetElement *html.Node) string {
+	// Start with the target element itself
+	var contentNodes []*html.Node
+	contentNodes = append(contentNodes, targetElement)
+
+	// Find the nearest sectioning container
+	sectionContainer := findNearestSectioningContainer(targetElement)
+	if sectionContainer == nil {
+		return renderNode(targetElement)
+	}
+
+	// Find the parent element that is a direct child of the sectioning container
+	var parentInSection *html.Node
+	current := targetElement.Parent
+	for current != nil && current.Parent != sectionContainer {
+		current = current.Parent
+	}
+	parentInSection = current
+
+	if parentInSection == nil {
+		return renderNode(targetElement)
+	}
+
+	// Find the heading level that defines this section (if any)
+	var sectionHeadingLevel int
+	for sibling := sectionContainer.FirstChild; sibling != nil; sibling = sibling.NextSibling {
+		if sibling == parentInSection {
+			break
+		}
+		if isHeadingElement(sibling) {
+			sectionHeadingLevel = getHeadingLevel(sibling)
+		}
+	}
+
+	// Collect all sibling elements that come after the parent element within the section
+	collecting := false
+	for sibling := sectionContainer.FirstChild; sibling != nil; sibling = sibling.NextSibling {
+		if sibling == parentInSection {
+			collecting = true
+			continue // We already have content from this element (the target)
+		}
+
+		if collecting {
+			// Stop if we encounter another sectioning element
+			if isSectioningElement(sibling) {
+				break
+			}
+
+			// Stop if we encounter a heading of equal or higher level than the section heading
+			if isHeadingElement(sibling) && sectionHeadingLevel > 0 {
+				siblingLevel := getHeadingLevel(sibling)
+				if siblingLevel <= sectionHeadingLevel {
+					break
+				}
+			}
+
+			contentNodes = append(contentNodes, sibling)
+		}
+	}
+
+	// Render all collected nodes
+	var buf strings.Builder
+	for _, node := range contentNodes {
+		_ = html.Render(&buf, node)
+	}
+
+	return buf.String()
+}
+
+// collectSectionContent collects content starting from a heading element until section boundary
+func collectSectionContent(headingNode *html.Node) string {
+	if !isHeadingElement(headingNode) {
+		return renderNode(headingNode)
+	}
+
+	headingLevel := getHeadingLevel(headingNode)
+	var contentNodes []*html.Node
+	contentNodes = append(contentNodes, headingNode)
+
+	// Collect all following sibling nodes until we hit a section boundary
+	for sibling := headingNode.NextSibling; sibling != nil; sibling = sibling.NextSibling {
+		// Skip text nodes that are just whitespace
+		if sibling.Type == html.TextNode && strings.TrimSpace(sibling.Data) == "" {
+			continue
+		}
+
+		// If we encounter another heading of equal or higher level, stop
+		if isHeadingElement(sibling) {
+			siblingLevel := getHeadingLevel(sibling)
+			if siblingLevel <= headingLevel {
+				break
+			}
+		}
+
+		// If we encounter a sectioning element, stop
+		if isSectioningElement(sibling) {
+			break
+		}
+
+		contentNodes = append(contentNodes, sibling)
+	}
+
+	// Render all collected nodes
+	var buf strings.Builder
+	for _, node := range contentNodes {
+		_ = html.Render(&buf, node)
+	}
+
+	return buf.String()
+}
+
+// getContextualContent determines what content to extract based on element type
+func getContextualContent(n *html.Node) string {
+	// For heading elements, collect the entire section
+	if isHeadingElement(n) {
+		return collectSectionContent(n)
+	}
+
+	// For sectioning elements, capture the entire container
+	if isSectioningElement(n) {
+		return renderNode(n)
+	}
+
+	// For all other elements (non-heading, non-sectioning), collect content following the element within its section
+	return collectContentFollowingElement(n)
+}

--- a/internal/processor/html_parser_test.go
+++ b/internal/processor/html_parser_test.go
@@ -1,0 +1,169 @@
+package processor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSectionedContent(t *testing.T) {
+	parser := NewHTMLParser()
+	t.Run("simple sections", func(t *testing.T) {
+		html := `
+<section>
+	<h1 id="section-1">Section 1</h1>
+	<p>hey</p>
+</section>
+<section>
+	<h2 id="section-2">Section 2</h2>
+</section>`
+		doc, err := parser.Parse([]byte(html))
+		if err != nil {
+			t.Errorf("Parse(%q) = %v, want nil", html, err)
+		}
+		expected := `<h1 id="section-1">Section 1</h1><p>hey</p>`
+
+		sectionedContent, err := doc.GetAnchoredSection("section-1")
+		if err != nil {
+			t.Errorf("GetAnchoredSection(%q) = %v, want nil", "section-1", err)
+		}
+		if sectionedContent != expected {
+			t.Errorf("Expected anchor for section-1, got %q", sectionedContent)
+		}
+
+	})
+}
+
+func TestUnsectionedContent(t *testing.T) {
+	parser := NewHTMLParser()
+	t.Run("one level", func(t *testing.T) {
+		html := `
+<main>
+	<h1>Section 1</h1>
+	<p>row 1</p>
+	<h1>Section 2</h1>
+	<p>
+	    <dfn id="my-def">some def</dfn> content
+	</p>
+	<p>
+		next
+	</p>
+	<h1>Section 3</h1>
+	<p>another</p>
+</main>`
+
+		doc, err := parser.Parse([]byte(html))
+		if err != nil {
+			t.Errorf("Parse(%q) = %v, want nil", html, err)
+		}
+
+		// expected := `<h1>Section 2</h1><p><dfn id="my-def">some def</dfn> content</p><p>next</p>`
+		sectionedContent, err := doc.GetAnchoredSection("my-def")
+		if err != nil {
+			t.Errorf("GetAnchoredSection(%q) = %v, want nil", "my-def", err)
+		}
+		if strings.Contains(sectionedContent, "Section 3") {
+			t.Errorf("Section 3 should not be included")
+		}
+
+	})
+}
+
+func TestFilterUnwantedElements(t *testing.T) {
+	parser := NewHTMLParser()
+	t.Run("filters script and style tags", func(t *testing.T) {
+		html := `
+<main>
+	<h1>Section 1</h1>
+	<script>alert('malicious');</script>
+	<p id="content">This is content</p>
+	<style>body { color: red; }</style>
+	<div>More content</div>
+</main>`
+
+		doc, err := parser.Parse([]byte(html))
+		if err != nil {
+			t.Errorf("Parse(%q) = %v, want nil", html, err)
+		}
+
+		sectionedContent, err := doc.GetAnchoredSection("content")
+		if err != nil {
+			t.Errorf("GetAnchoredSection(%q) = %v, want nil", "content", err)
+		}
+		if strings.Contains(sectionedContent, "script") {
+			t.Errorf("Script tag should be filtered out")
+		}
+		if strings.Contains(sectionedContent, "alert") {
+			t.Errorf("Script content should be filtered out")
+		}
+		if strings.Contains(sectionedContent, "style") {
+			t.Errorf("Style tag should be filtered out")
+		}
+		if strings.Contains(sectionedContent, "color: red") {
+			t.Errorf("Style content should be filtered out")
+		}
+		if !strings.Contains(sectionedContent, "This is content") {
+			t.Errorf("Actual content should be preserved")
+		}
+		// The main test here is that unwanted elements are filtered out
+		// Content collection behavior is tested separately
+	})
+
+	t.Run("filters unwanted attributes", func(t *testing.T) {
+		html := `
+<main>
+	<h1>Section 1</h1>
+	<p id="content" class="highlight" style="color: red;" onclick="alert('click')" data-test="value">
+		This is content with <a href="http://example.com" target="_blank" rel="noopener" download>a link</a>
+	</p>
+</main>`
+
+		doc, err := parser.Parse([]byte(html))
+		if err != nil {
+			t.Errorf("Parse(%q) = %v, want nil", html, err)
+		}
+
+		sectionedContent, err := doc.GetAnchoredSection("content")
+		if err != nil {
+			t.Errorf("GetAnchoredSection(%q) = %v, want nil", "content", err)
+		}
+
+		// Should filter out unwanted attributes
+		if strings.Contains(sectionedContent, "class=") {
+			t.Errorf("class attribute should be filtered out")
+		}
+		if strings.Contains(sectionedContent, "style=") {
+			t.Errorf("style attribute should be filtered out")
+		}
+		if strings.Contains(sectionedContent, "onclick=") {
+			t.Errorf("onclick attribute should be filtered out")
+		}
+		if strings.Contains(sectionedContent, "data-test=") {
+			t.Errorf("data-* attributes should be filtered out")
+		}
+		if strings.Contains(sectionedContent, "target=") {
+			t.Errorf("target attribute should be filtered out")
+		}
+		if strings.Contains(sectionedContent, "rel=") {
+			t.Errorf("rel attribute should be filtered out")
+		}
+		if strings.Contains(sectionedContent, "download") {
+			t.Errorf("download attribute should be filtered out")
+		}
+
+		// Should preserve id and href attributes
+		if !strings.Contains(sectionedContent, `id="content"`) {
+			t.Errorf("id attribute should be preserved")
+		}
+		if !strings.Contains(sectionedContent, `href="http://example.com"`) {
+			t.Errorf("href attribute should be preserved")
+		}
+
+		// Should preserve text content
+		if !strings.Contains(sectionedContent, "This is content") {
+			t.Errorf("Text content should be preserved")
+		}
+		if !strings.Contains(sectionedContent, "a link") {
+			t.Errorf("Link text should be preserved")
+		}
+	})
+}

--- a/internal/processor/markdown_parser.go
+++ b/internal/processor/markdown_parser.go
@@ -1,0 +1,173 @@
+package processor
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+)
+
+// Compile regex once at package level for efficiency
+var anchorRegex = regexp.MustCompile(`[^a-z0-9]+`)
+
+type markdownParser struct{}
+
+func NewMarkdownParser() DocumentParser {
+	return &markdownParser{}
+}
+
+func (p *markdownParser) Parse(content []byte) (StructuredDocument, error) {
+	anchors := make(map[string]string)
+
+	// Parse markdown using goldmark
+	md := goldmark.New()
+	doc := md.Parser().Parse(text.NewReader(content))
+
+	// Collect all headings with their positions
+	var headings []headingInfo
+	err := ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if entering && node.Kind() == ast.KindHeading {
+			heading := node.(*ast.Heading)
+			headingText := extractNodeText(heading, content)
+			anchor := generateAnchor(headingText)
+
+			headings = append(headings, headingInfo{
+				node:   node,
+				anchor: anchor,
+				level:  heading.Level,
+			})
+		}
+		return ast.WalkContinue, nil
+	})
+	if err != nil {
+		return StructuredDocument{}, err
+	}
+
+	// Extract content for each heading
+	anchorCounts := make(map[string]int)
+	for i, heading := range headings {
+		// Handle duplicate anchors by appending a number
+		anchor := heading.anchor
+		if count, exists := anchorCounts[heading.anchor]; exists {
+			anchor = fmt.Sprintf("%s-%d", heading.anchor, count+1)
+			anchorCounts[heading.anchor]++
+		} else {
+			anchorCounts[heading.anchor] = 1
+		}
+
+		sectionContent := extractSectionContentBetweenHeadings(heading.node, getNextSameLevelOrHigher(headings, i), content)
+		anchors[anchor] = sectionContent
+	}
+
+	return StructuredDocument{
+		Type:    Markdown,
+		content: content,
+		anchors: anchors,
+	}, nil
+}
+
+type headingInfo struct {
+	node   ast.Node
+	anchor string
+	level  int
+}
+
+func extractNodeText(node ast.Node, source []byte) string {
+	var sb strings.Builder
+	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
+		if child.Kind() == ast.KindText {
+			if textNode, ok := child.(*ast.Text); ok {
+				sb.Write(textNode.Value(source))
+			}
+		}
+	}
+	return sb.String()
+}
+
+func generateAnchor(text string) string {
+	// Convert to lowercase
+	anchor := strings.ToLower(text)
+
+	// Replace spaces and other characters with hyphens
+	anchor = anchorRegex.ReplaceAllString(anchor, "-")
+
+	// Remove leading/trailing hyphens
+	anchor = strings.Trim(anchor, "-")
+
+	return anchor
+}
+
+func getNextSameLevelOrHigher(headings []headingInfo, currentIndex int) ast.Node {
+	if currentIndex >= len(headings)-1 {
+		return nil
+	}
+
+	currentLevel := headings[currentIndex].level
+
+	// Find the next heading at the same level or higher (lower number)
+	// This ensures sections include all nested content
+	for i := currentIndex + 1; i < len(headings); i++ {
+		if headings[i].level <= currentLevel {
+			return headings[i].node
+		}
+	}
+	return nil
+}
+
+func extractSectionContentBetweenHeadings(startHeading, endHeading ast.Node, source []byte) string {
+	var content bytes.Buffer
+
+	// Start from the node after the heading
+	current := startHeading.NextSibling()
+
+	for current != nil && current != endHeading {
+		// Include ALL content - both headings and non-heading content
+		nodeContent := extractFullNodeText(current, source)
+		if nodeContent != "" {
+			if content.Len() > 0 {
+				content.WriteString("\n")
+			}
+			content.WriteString(nodeContent)
+		}
+		current = current.NextSibling()
+	}
+
+	return strings.TrimSpace(content.String())
+}
+
+func extractFullNodeText(node ast.Node, source []byte) string {
+	var parts []string
+
+	if node.Kind() == ast.KindParagraph {
+		// For paragraphs, collect text nodes and join with newlines to preserve line breaks
+		var texts []string
+		for child := node.FirstChild(); child != nil; child = child.NextSibling() {
+			if child.Kind() == ast.KindText {
+				if textNode, ok := child.(*ast.Text); ok {
+					texts = append(texts, string(textNode.Value(source)))
+				}
+			}
+		}
+		if len(texts) > 0 {
+			parts = append(parts, strings.Join(texts, "\n"))
+		}
+	} else {
+		// For other nodes, walk and collect text
+		err := ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+			if entering && n.Kind() == ast.KindText {
+				if textNode, ok := n.(*ast.Text); ok {
+					parts = append(parts, string(textNode.Value(source)))
+				}
+			}
+			return ast.WalkContinue, nil
+		})
+		// Note: ast.Walk in goldmark typically doesn't return errors for simple traversal
+		_ = err
+	}
+
+	return strings.TrimSpace(strings.Join(parts, ""))
+}

--- a/internal/processor/markdown_parser_test.go
+++ b/internal/processor/markdown_parser_test.go
@@ -1,0 +1,217 @@
+package processor
+
+import (
+	"testing"
+)
+
+func TestMarkdownParser_Parse(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected map[string]string
+	}{
+		{
+			name: "simple headings with content",
+			content: `# Main Title
+
+This is the main content under the title.
+
+## Section One
+
+Content for section one.
+Some more content here.
+
+## Section Two
+
+Content for section two.
+
+### Subsection
+
+Subsection content.
+
+## Final Section
+
+Final content.`,
+			expected: map[string]string{
+				"main-title":    "This is the main content under the title.\nSection One\nContent for section one.\nSome more content here.\nSection Two\nContent for section two.\nSubsection\nSubsection content.\nFinal Section\nFinal content.",
+				"section-one":   "Content for section one.\nSome more content here.",
+				"section-two":   "Content for section two.\nSubsection\nSubsection content.",
+				"subsection":    "Subsection content.",
+				"final-section": "Final content.",
+			},
+		},
+		{
+			name: "headings with special characters",
+			content: `# Title with Special & Characters!
+
+Content here.
+
+## Section: With Colon
+
+More content.`,
+			expected: map[string]string{
+				"title-with-special-characters": "Content here.\nSection: With Colon\nMore content.",
+				"section-with-colon":            "More content.",
+			},
+		},
+		{
+			name: "nested heading levels",
+			content: `# Level 1
+
+Content at level 1.
+
+## Level 2
+
+Content at level 2.
+
+### Level 3
+
+Content at level 3.
+
+#### Level 4
+
+Content at level 4.
+
+## Another Level 2
+
+Back to level 2.`,
+			expected: map[string]string{
+				"level-1":         "Content at level 1.\nLevel 2\nContent at level 2.\nLevel 3\nContent at level 3.\nLevel 4\nContent at level 4.\nAnother Level 2\nBack to level 2.",
+				"level-2":         "Content at level 2.\nLevel 3\nContent at level 3.\nLevel 4\nContent at level 4.",
+				"level-3":         "Content at level 3.\nLevel 4\nContent at level 4.",
+				"level-4":         "Content at level 4.",
+				"another-level-2": "Back to level 2.",
+			},
+		},
+		{
+			name: "empty sections",
+			content: `# First Section
+
+## Empty Section
+
+## Section with Content
+
+This has content.`,
+			expected: map[string]string{
+				"first-section":        "Empty Section\nSection with Content\nThis has content.",
+				"empty-section":        "",
+				"section-with-content": "This has content.",
+			},
+		},
+		{
+			name: "nested content inclusion",
+			content: `# level 1
+hey
+## level 2
+there`,
+			expected: map[string]string{
+				"level-1": "hey\nlevel 2\nthere",
+				"level-2": "there",
+			},
+		},
+		{
+			name: "duplicate anchor handling",
+			content: `# Test Section
+
+Content 1
+
+# Test Section
+
+Content 2
+
+## Test Section
+
+Content 3`,
+			expected: map[string]string{
+				"test-section":   "Content 1",
+				"test-section-2": "Content 2\nTest Section\nContent 3",
+				"test-section-3": "Content 3",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := NewMarkdownParser()
+			result, err := parser.Parse([]byte(tt.content))
+
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+
+			if result.Type != Markdown {
+				t.Errorf("Parse() Type = %v, want %v", result.Type, Markdown)
+			}
+
+			if len(result.anchors) != len(tt.expected) {
+				t.Errorf("Parse() anchors count = %v, want %v", len(result.anchors), len(tt.expected))
+			}
+
+			for expectedAnchor, expectedContent := range tt.expected {
+				actualContent, exists := result.anchors[expectedAnchor]
+				if !exists {
+					t.Errorf("Parse() missing anchor %q", expectedAnchor)
+					continue
+				}
+
+				if actualContent != expectedContent {
+					t.Errorf("Parse() anchor %q content = %q, want %q", expectedAnchor, actualContent, expectedContent)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateAnchor(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Simple Title", "simple-title"},
+		{"Title with Special & Characters!", "title-with-special-characters"},
+		{"  Spaces   Around  ", "spaces-around"},
+		{"UPPERCASE", "uppercase"},
+		{"Title: With Colon", "title-with-colon"},
+		{"Numbers 123 Test", "numbers-123-test"},
+		{"Multiple---Dashes", "multiple-dashes"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := generateAnchor(tt.input)
+			if result != tt.expected {
+				t.Errorf("generateAnchor(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStructuredDocument_GetSubsection(t *testing.T) {
+	doc := StructuredDocument{
+		Type:    Markdown,
+		content: []byte("test content"),
+		anchors: map[string]string{
+			"section-one": "Content one",
+			"section-two": "Content two",
+		},
+	}
+
+	tests := []struct {
+		anchor   string
+		expected string
+	}{
+		{"section-one", "Content one"},
+		{"section-two", "Content two"},
+		{"nonexistent", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.anchor, func(t *testing.T) {
+			result := doc.GetSubsection(tt.anchor)
+			if result != tt.expected {
+				t.Errorf("GetSubsection(%q) = %q, want %q", tt.anchor, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/processor/markdown_parser_test.go
+++ b/internal/processor/markdown_parser_test.go
@@ -33,11 +33,11 @@ Subsection content.
 
 Final content.`,
 			expected: map[string]string{
-				"main-title":    "This is the main content under the title.\nSection One\nContent for section one.\nSome more content here.\nSection Two\nContent for section two.\nSubsection\nSubsection content.\nFinal Section\nFinal content.",
-				"section-one":   "Content for section one.\nSome more content here.",
-				"section-two":   "Content for section two.\nSubsection\nSubsection content.",
-				"subsection":    "Subsection content.",
-				"final-section": "Final content.",
+				"main-title":    "# Main Title\n\nThis is the main content under the title.\n\n## Section One\n\nContent for section one.\nSome more content here.\n\n## Section Two\n\nContent for section two.\n\n### Subsection\n\nSubsection content.\n\n## Final Section\n\nFinal content.",
+				"section-one":   "## Section One\n\nContent for section one.\nSome more content here.",
+				"section-two":   "## Section Two\n\nContent for section two.\n\n### Subsection\n\nSubsection content.",
+				"subsection":    "### Subsection\n\nSubsection content.",
+				"final-section": "## Final Section\n\nFinal content.",
 			},
 		},
 		{
@@ -50,8 +50,8 @@ Content here.
 
 More content.`,
 			expected: map[string]string{
-				"title-with-special-characters": "Content here.\nSection: With Colon\nMore content.",
-				"section-with-colon":            "More content.",
+				"title-with-special-characters": "# Title with Special & Characters!\n\nContent here.\n\n## Section: With Colon\n\nMore content.",
+				"section-with-colon":            "## Section: With Colon\n\nMore content.",
 			},
 		},
 		{
@@ -76,11 +76,11 @@ Content at level 4.
 
 Back to level 2.`,
 			expected: map[string]string{
-				"level-1":         "Content at level 1.\nLevel 2\nContent at level 2.\nLevel 3\nContent at level 3.\nLevel 4\nContent at level 4.\nAnother Level 2\nBack to level 2.",
-				"level-2":         "Content at level 2.\nLevel 3\nContent at level 3.\nLevel 4\nContent at level 4.",
-				"level-3":         "Content at level 3.\nLevel 4\nContent at level 4.",
-				"level-4":         "Content at level 4.",
-				"another-level-2": "Back to level 2.",
+				"level-1":         "# Level 1\n\nContent at level 1.\n\n## Level 2\n\nContent at level 2.\n\n### Level 3\n\nContent at level 3.\n\n#### Level 4\n\nContent at level 4.\n\n## Another Level 2\n\nBack to level 2.",
+				"level-2":         "## Level 2\n\nContent at level 2.\n\n### Level 3\n\nContent at level 3.\n\n#### Level 4\n\nContent at level 4.",
+				"level-3":         "### Level 3\n\nContent at level 3.\n\n#### Level 4\n\nContent at level 4.",
+				"level-4":         "#### Level 4\n\nContent at level 4.",
+				"another-level-2": "## Another Level 2\n\nBack to level 2.",
 			},
 		},
 		{
@@ -93,9 +93,9 @@ Back to level 2.`,
 
 This has content.`,
 			expected: map[string]string{
-				"first-section":        "Empty Section\nSection with Content\nThis has content.",
-				"empty-section":        "",
-				"section-with-content": "This has content.",
+				"first-section":        "# First Section\n\n## Empty Section\n\n## Section with Content\n\nThis has content.",
+				"empty-section":        "## Empty Section",
+				"section-with-content": "## Section with Content\n\nThis has content.",
 			},
 		},
 		{
@@ -105,8 +105,8 @@ hey
 ## level 2
 there`,
 			expected: map[string]string{
-				"level-1": "hey\nlevel 2\nthere",
-				"level-2": "there",
+				"level-1": "# level 1\nhey\n## level 2\nthere",
+				"level-2": "## level 2\nthere",
 			},
 		},
 		{
@@ -123,9 +123,9 @@ Content 2
 
 Content 3`,
 			expected: map[string]string{
-				"test-section":   "Content 1",
-				"test-section-2": "Content 2\nTest Section\nContent 3",
-				"test-section-3": "Content 3",
+				"test-section":   "# Test Section\n\nContent 1",
+				"test-section-2": "# Test Section\n\nContent 2\n\n## Test Section\n\nContent 3",
+				"test-section-3": "## Test Section\n\nContent 3",
 			},
 		},
 	}

--- a/internal/processor/markdown_parser_test.go
+++ b/internal/processor/markdown_parser_test.go
@@ -208,7 +208,10 @@ func TestStructuredDocument_GetSubsection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.anchor, func(t *testing.T) {
-			result := doc.GetAnchoredSection(tt.anchor)
+			result, err := doc.GetAnchoredSection(tt.anchor)
+			if err != nil {
+				t.Errorf("GetAnchoredSection(%q) = %v, want nil", tt.anchor, err)
+			}
 			if result != tt.expected {
 				t.Errorf("GetAnchoredSection(%q) = %q, want %q", tt.anchor, result, tt.expected)
 			}

--- a/internal/processor/markdown_parser_test.go
+++ b/internal/processor/markdown_parser_test.go
@@ -179,7 +179,7 @@ func TestGenerateAnchor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			result := generateAnchor(tt.input)
+			result := textToAnchor(tt.input)
 			if result != tt.expected {
 				t.Errorf("generateAnchor(%q) = %q, want %q", tt.input, result, tt.expected)
 			}
@@ -188,7 +188,7 @@ func TestGenerateAnchor(t *testing.T) {
 }
 
 func TestStructuredDocument_GetSubsection(t *testing.T) {
-	doc := StructuredDocument{
+	doc := CollectedDocument{
 		Type:    Markdown,
 		content: []byte("test content"),
 		anchors: map[string]string{
@@ -208,9 +208,9 @@ func TestStructuredDocument_GetSubsection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.anchor, func(t *testing.T) {
-			result := doc.GetSubsection(tt.anchor)
+			result := doc.GetAnchoredSection(tt.anchor)
 			if result != tt.expected {
-				t.Errorf("GetSubsection(%q) = %q, want %q", tt.anchor, result, tt.expected)
+				t.Errorf("GetAnchoredSection(%q) = %q, want %q", tt.anchor, result, tt.expected)
 			}
 		})
 	}

--- a/internal/processor/rule_builder_test.go
+++ b/internal/processor/rule_builder_test.go
@@ -90,8 +90,8 @@ func helper() {
 		t.Errorf("Expected file reference to ./specs/api.md, got %v", test1Refs[0])
 	}
 
-	if test1Refs[1].Command != inline.RFC || len(test1Refs[1].Args) == 0 || test1Refs[1].Args[0] != "https://www.rfc-editor.org/rfc/rfc1234.txt" {
-		t.Errorf("Expected RFC reference to https://www.rfc-editor.org/rfc/rfc1234.txt, got %v", test1Refs[1])
+	if test1Refs[1].Command != inline.RFC || len(test1Refs[1].Args) == 0 || test1Refs[1].Args[0] != "https://datatracker.ietf.org/doc/html/rfc1234" {
+		t.Errorf("Expected RFC reference to https://datatracker.ietf.org/doc/html/rfc1234, got %v", test1Refs[1])
 	}
 
 	// Check test2.go references

--- a/site/src/components/quickstart.astro
+++ b/site/src/components/quickstart.astro
@@ -26,7 +26,7 @@ import runCode from "../code-samples/run.sh?raw";
       </p>
 
       <div class="space-y-3">
-        <h4 class="text-md font-medium text-gray-800">1. Inline spec references (recommended)</h4>
+        <h4 class="text-md font-medium text-gray-800">1. Inline spec references</h4>
         <p class="text-sm text-gray-600">
           Link specifications directly in your code using special comment syntax:
         </p>
@@ -41,13 +41,18 @@ class JsonParser:
         <Code
           code=`semcheck:file(./local/spec.md)  # Link repo local files
 semcheck:url(https://example.com/docs/api)  # Link to remote documents
-semcheck:rfc(8259)  # Shorthand for linking to RFC documents on rfc-editor.org`
+semcheck:rfc(8259)  # Shorthand for linking to RFC documents on datatracker.ietf.org
+
+# Target specific sections using fragments:
+semcheck:url(https://www.rfc-editor.org/rfc/rfc7946.html#section-3.1.1)  # HTML sections
+semcheck:file(./docs/api-spec.md#authentication)  # In Markdown refer to heading text directly
+semcheck:rfc(8259#section-8.3)  # Shorthand for https://datatracker.ietf.org/doc/html/rfc8259#section-8.3`
           lang="python"
         />
       </div>
 
       <div class="space-y-3">
-        <h4 class="text-md font-medium text-gray-800">2. Rules (advanced)</h4>
+        <h4 class="text-md font-medium text-gray-800">2. Rules</h4>
         <p class="text-sm text-gray-600">
           Define rules in your <code>semcheck.yaml</code> configuration that tie specification files
           to implementation files:

--- a/specs/semcheck.md
+++ b/specs/semcheck.md
@@ -135,6 +135,12 @@ rules:
       # Example of URL specification
       - path: "https://www.rfc-editor.org/rfc/rfc7946.txt"
 
+      # Use Anchors to include only a subsection of a document
+      - path: "specs/api.md#section-3.1"
+
+      # Also works for URIs
+      - path: "https://datatracker.ietf.org/doc/html/rfc7946#section-5"
+
     # Additional context for AI analysis (OPTIONAL)
     # Custom instructions to guide the semantic checking process
     # Use cases:


### PR DESCRIPTION
If your spec file is structured, which is true for markdown, rst and html, then you can use "anchor" links to link to specific parts of that document. This already works on the web like so:

https://github.com/rejot-dev/semcheck/#link-specification-and-implementation

For local files this isn't strictly defined, but I think we can add it as a nice feature

`./specs/my-spec-file.md#section-1-1`